### PR TITLE
MVP(init): Preserve compose.yaml order after placeholders are added.

### DIFF
--- a/pkg/kev/config/infer.go
+++ b/pkg/kev/config/infer.go
@@ -65,18 +65,18 @@ func Infer(data []byte) (Inferred, error) {
 		appConfig.Components[s.Name] = *c
 	}
 
-	composeBytes, err := yaml.Marshal(composeConfig)
+	rawCompose, err := yaml.Marshal(composeConfig)
 	if err != nil {
 		return Inferred{}, err
 	}
 
-	composeBytesWithPlaceholders, err := injectPlaceholders(composeBytes)
+	rawComposeWithPlaceholders, err := injectPlaceholders(rawCompose)
 	if err != nil {
 		return Inferred{}, err
 	}
 
 	return Inferred{
-		ComposeWithPlaceholders: composeBytesWithPlaceholders,
+		ComposeWithPlaceholders: rawComposeWithPlaceholders,
 		AppConfig:               appConfig,
 	}, nil
 }
@@ -262,7 +262,15 @@ func injectPlaceholders(data []byte) ([]byte, error) {
 		}
 	}
 
-	return utils.MarshallAndFormat(composeConfig, 2)
+	out := ShallowComposeConfig{
+		Version:  composeConfig["version"].(string),
+		Services: composeConfig["services"],
+		Networks: composeConfig["networks"],
+		Volumes:  composeConfig["volumes"],
+		Secrets:  composeConfig["secrets"],
+		Configs:  composeConfig["configs"],
+	}
+	return utils.MarshallAndFormat(out, 2)
 }
 
 // Builds config attribute value placeholder

--- a/pkg/kev/config/types.go
+++ b/pkg/kev/config/types.go
@@ -119,3 +119,13 @@ type CompiledConfig struct {
 	Content     []byte
 	File        string
 }
+
+// ShallowComposeConfig is used to ensure marshaled output is ordered correctly.
+type ShallowComposeConfig struct {
+	Version  string      `json:"version"`
+	Services interface{} `json:"services"`
+	Networks interface{} `yaml:",omitempty" json:"networks,omitempty"`
+	Volumes  interface{} `yaml:",omitempty" json:"volumes,omitempty"`
+	Secrets  interface{} `yaml:",omitempty" json:"secrets,omitempty"`
+	Configs  interface{} `yaml:",omitempty" json:"configs,omitempty"`
+}


### PR DESCRIPTION
This resolves https://github.com/appvia/kube-devx/issues/69

- Added a `ShallowComposeConfig` to preserve compose.yaml ordering.