### PR TITLE
Config.yaml bool values set to `false` go missing during serialisation.

### DIFF
--- a/pkg/kev/config/infer.go
+++ b/pkg/kev/config/infer.go
@@ -205,8 +205,7 @@ func inferDeploymentInfo(s *compose.ServiceConfig, cmp *Component) {
 func inferHealthcheckInfo(s *compose.ServiceConfig, cmp *Component) {
 	// get workload object
 	w := cmp.Workload
-
-	w.LivenessProbeDisable = s.HealthCheck.Disable
+	w.LivenessProbeDisable = &s.HealthCheck.Disable
 	w.LivenessProbeCommand = s.HealthCheck.Test
 	w.LivenessProbeInterval = s.HealthCheck.Interval.String()
 	w.LivenessProbeInitialDelay = s.HealthCheck.StartPeriod.String()

--- a/pkg/kev/config/types.go
+++ b/pkg/kev/config/types.go
@@ -49,7 +49,7 @@ type Workload struct {
 	// max-memory, Default: 100M. Memory limit per workload.
 	MaxMemory string `yaml:"max-memory,omitempty" json:"max_memory,omitempty" default:"100M"`
 	// liveness-probe-disable, Default: false. Whether to enable liveness probe.
-	LivenessProbeDisable bool `yaml:"liveness-probe-disable,omitempty" json:"liveness_probe_disable,omitempty" default:"false"`
+	LivenessProbeDisable *bool `yaml:"liveness-probe-disable,omitempty" json:"liveness_probe_disable,omitempty" default:"false"`
 	// liveness-probe-interval, Default: 1m. Liveness probe interval.
 	LivenessProbeInterval string `yaml:"liveness-probe-interval,omitempty" json:"liveness_probe_interval,omitempty" default:"1m"`
 	// liveness-probe-retries, Default: 3. Liveness probe retry limit.


### PR DESCRIPTION
This resolves https://github.com/appvia/kube-devx/issues/79

**The fix**

- Use a pointer to ensure a `bool` zero value is nil rather than `false`.
- This ensures `false` attributes are not omitted during yaml/json serialization.