### PR TITLE
Give access to different build details depending on render/display scenario.

### DIFF
--- a/cmd/kev/cmd/build.go
+++ b/cmd/kev/cmd/build.go
@@ -83,8 +83,7 @@ func runBuildCmd(cmd *cobra.Command, _ []string) error {
 		return err
 	}
 
-	builtEnvs := make(map[string]bool)
-	for env, build := range def.GetBuildInfo() {
+	for _, build := range def.GetInternalBuildInfo() {
 		if err := os.MkdirAll(build.Config.Path(), os.ModePerm); err != nil {
 			return err
 		}
@@ -95,16 +94,27 @@ func runBuildCmd(cmd *cobra.Command, _ []string) error {
 		if err = ioutil.WriteFile(build.Compose.File, build.Compose.Content, os.ModePerm); err != nil {
 			return err
 		}
-		builtEnvs[env] = true
 	}
 
-	displayBuild(builtEnvs)
+	displayBuild(def)
 	return nil
 }
 
-func displayBuild(builtEnvsSet map[string]bool) {
+func displayBuild(def *app.Definition) {
+	if def.HasBuiltOverrides() {
+		displayEnvsBuilt(def.GetOverridesBuildInfo())
+	} else {
+		displayAppBuilt()
+	}
+}
+
+func displayEnvsBuilt(builtEnvsSet map[string]app.ConfigTuple) {
 	for k := range builtEnvsSet {
 		fmt.Printf("🔧 [%s] environment ready.\n", k)
 	}
-	fmt.Println("🔩 App builds complete!")
+	displayAppBuilt()
+}
+
+func displayAppBuilt() {
+	fmt.Println("🔩 App build complete!")
 }

--- a/pkg/kev/app/build.go
+++ b/pkg/kev/app/build.go
@@ -25,15 +25,30 @@ import (
 	"github.com/imdario/mergo"
 )
 
-// GetBuildInfo get the latest info as map of overrides and config pairs.
+// GetInternalBuildInfo is mostly used INTERNALLY to get the latest info as map of overrides and config pairs.
 // The build's base config is added under the key defined by the Base constant.
-func (def *Definition) GetBuildInfo() map[string]ConfigTuple {
+func (def *Definition) GetInternalBuildInfo() map[string]ConfigTuple {
 	out := map[string]ConfigTuple{}
 	out[Base] = def.Build.Base
 	for override, pair := range def.Build.Overrides {
 		out[override] = pair
 	}
 	return out
+}
+
+// HasBuiltOverrides informs whether the Build contains overrides.
+func (def *Definition) HasBuiltOverrides() bool {
+	return len(def.Build.Overrides) > 0
+}
+
+// GetAppBuildInfo returns the base app build info, used for build display and manifest render of app only.
+func (def *Definition) GetAppBuildInfo() ConfigTuple {
+	return def.Build.Base
+}
+
+// GetOverridesBuildInfo returns the overrides build info, used for build display and manifest render of envs only.
+func (def *Definition) GetOverridesBuildInfo() map[string]ConfigTuple {
+	return def.Build.Overrides
 }
 
 // DoBuild builds an app definition manifest


### PR DESCRIPTION
This provides 4 new different methods to cater of render and display needs,

- `Definition.GetInternalBuildInfo`
- `Definition.HasBuiltOverrides`
- `Definition.GetAppBuildInfo`
- `Definition.GetOverridesBuildInfo`

This should enable our previous discussion on Slack.