### PR TITLE
MVP (init-labels): re-work init to create label based config per required environment using the current infer rules.

### DIFF
--- a/pkg/kev.v2/compose.go
+++ b/pkg/kev.v2/compose.go
@@ -1,0 +1,92 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kev
+
+import (
+	"io/ioutil"
+
+	"github.com/compose-spec/compose-go/cli"
+	composego "github.com/compose-spec/compose-go/types"
+	"gopkg.in/yaml.v2"
+)
+
+// newComposeProject loads and parses a set of input compose files and returns a composeProject object
+func newComposeProject(paths []string) (*composeProject, error) {
+	raw, err := rawProjectFromSources(paths)
+	if err != nil {
+		return nil, err
+	}
+	version, err := getComposeVersion(paths[0])
+	if err != nil {
+		return nil, err
+	}
+
+	return (&composeProject{version, raw}).transform()
+}
+
+func (p *composeProject) transform() (*composeProject, error) {
+	transforms := []transform{
+		augmentOrAddDeploy,
+		healthCheckBase,
+	}
+	for _, t := range transforms {
+		if err := t(p); err != nil {
+			return nil, err
+		}
+	}
+	return p, nil
+}
+
+// rawProjectFromSources loads and parses a compose-go project from multiple docker-compose source files.
+func rawProjectFromSources(paths []string) (*composego.Project, error) {
+	projectOptions, err := cli.ProjectOptions{
+		ConfigPaths: paths,
+	}.
+		WithOsEnv().
+		WithDotEnv()
+
+	if err != nil {
+		return nil, err
+	}
+
+	project, err := cli.ProjectFromOptions(&projectOptions)
+	if err != nil {
+		return nil, err
+	}
+
+	for i := range project.Services {
+		project.Services[i].EnvFile = nil
+	}
+	return project, nil
+}
+
+// getComposeVersion extracts version from compose file and returns a string
+func getComposeVersion(file string) (string, error) {
+	version := struct {
+		Version string `json:"version"` // This affects YAML as well
+	}{}
+
+	compose, err := ioutil.ReadFile(file)
+	if err != nil {
+		return "", err
+	}
+
+	if err = yaml.Unmarshal(compose, &version); err != nil {
+		return "", err
+	}
+	return version.Version, nil
+}

--- a/pkg/kev.v2/defaults.go
+++ b/pkg/kev.v2/defaults.go
@@ -1,0 +1,131 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kev
+
+const (
+	// DefaultVolumeSize default value PV class
+	DefaultVolumeSize = "100Mi"
+
+	// DefaultVolumeClass default PV size
+	DefaultVolumeClass = "standard"
+
+	// DefaultService is a default service
+	DefaultService = NoService
+
+	// DefaultRestartPolicy is a default restart policy
+	DefaultRestartPolicy = RestartPolicyAlways
+
+	// DefaultWorkload is a defauld workload type
+	DefaultWorkload = DeploymentWorkload
+
+	// DefaultServiceAccountName is a default SA to be used
+	DefaultServiceAccountName = "default"
+
+	// DefaultImagePullPolicy default image pull policy
+	DefaultImagePullPolicy = "IfNotPresent"
+
+	// DefaultImagePullSecret default image pull credentials secret name
+	DefaultImagePullSecret = ""
+
+	// DefaultSecurityContextRunAsUser default UID for pod security context
+	DefaultSecurityContextRunAsUser = ""
+
+	// DefaultSecurityContextRunAsGroup default GID for pod security context
+	DefaultSecurityContextRunAsGroup = ""
+
+	// DefaultSecurityContextFsGroup default fs Group for pod security context
+	DefaultSecurityContextFsGroup = ""
+
+	// NoService default value
+	NoService = "None"
+
+	// NodePortService svc type
+	NodePortService = "NodePort"
+
+	// LoadBalancerService svc type
+	LoadBalancerService = "LoadBalancer"
+
+	// ClusterIPService svc type
+	ClusterIPService = "ClusterIP"
+
+	// HeadlessService svc type
+	HeadlessService = "Headless"
+
+	// RestartPolicyAlways default value
+	RestartPolicyAlways = "Always"
+
+	// RestartPolicyOnFailure restart policy
+	RestartPolicyOnFailure = "OnFailure"
+
+	// RestartPolicyNever restart policy
+	RestartPolicyNever = "Never"
+
+	// DeploymentWorkload workload type
+	DeploymentWorkload = "Deployment"
+
+	// DaemonsetWorkload workload type
+	DaemonsetWorkload = "DaemonSet"
+
+	// StatefulsetWorkload workload type
+	StatefulsetWorkload = "StatefulSet"
+
+	// JobWorkload workload type
+	JobWorkload = "Job"
+
+	// DefaultReplicaNumber default number of replicas per workload
+	DefaultReplicaNumber = 1
+
+	// defaultRollingUpdateMaxSurge default number of containers to be updated at a time
+	defaultRollingUpdateMaxSurge = 1
+
+	// defaultResourceLimitMem default Memory resource limit
+	// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
+	defaultResourceLimitMem = "500Mi"
+
+	// defaultResourceRequestMem default Memory resource request
+	// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
+	defaultResourceRequestMem = "10Mi"
+
+	// Kubernetes notation details: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu
+	// Default: 0.5, which is equivalent to 50% of CPU
+	defaultResourceLimitCPU = "0.5"
+
+	// defaultResourceRequestCPU default CPU resource request
+	// This value follows docker compose resource notation
+	// https://docs.docker.com/compose/compose-file/#resources
+	// Kubernetes notation details: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu
+	// Default: 0.1, which is equivalent to 10% of CPU
+	defaultResourceRequestCPU = "0.1"
+
+	// defaultLivenessProbeCommand default command
+	defaultLivenessProbeCommand = "Define healthcheck command for service %s"
+
+	// defaultLivenessProbeTimeout default 10s
+	defaultLivenessProbeTimeout = "10s"
+
+	// defaultLivenessProbeInterval default 1m (1 minute)
+	defaultLivenessProbeInterval = "1m"
+
+	// defaultLivenessProbeInitialDelay default 1m (1 minute)
+	defaultLivenessProbeInitialDelay = "1m"
+
+	// defaultLivenessProbeRetries default 3. Number of retries for liveness probe command
+	defaultLivenessProbeRetries = 3
+
+	// defaultLivenessProbeDisable default false. Enabled by default
+	defaultLivenessProbeDisable = false
+)

--- a/pkg/kev.v2/extract.go
+++ b/pkg/kev.v2/extract.go
@@ -1,0 +1,194 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kev
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	composego "github.com/compose-spec/compose-go/types"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+// setDefaultLabels sets sensible workload defaults as labels.
+func setDefaultLabels(target *composego.ServiceConfig) {
+	target.Labels.Add("kev.workload.image-pull-policy", DefaultImagePullPolicy)
+	target.Labels.Add("kev.workload.service-account-name", DefaultServiceAccountName)
+}
+
+// extractVolumesLabels extracts volume labels into a label's Volumes attribute.
+func extractVolumesLabels(c *composeProject, out *labels) {
+	// Volumes map
+	vols := make(map[string]composego.VolumeConfig)
+
+	for _, v := range c.VolumeNames() {
+		vols[v] = composego.VolumeConfig{
+			Labels: map[string]string{
+				"kev.volumes.class": DefaultVolumeClass,
+				"kev.volumes.size":  DefaultVolumeSize,
+			},
+		}
+	}
+	out.Volumes = vols
+}
+
+// extractServiceTypeLabels extracts service type labels into a label's Service.
+func extractServiceTypeLabels(source composego.ServiceConfig, target *composego.ServiceConfig) {
+	if source.Ports == nil {
+		target.Labels.Add("kev.service.type", NoService)
+	} else {
+		for _, p := range source.Ports {
+			if p.Published != 0 && p.Mode == "host" {
+				target.Labels.Add("kev.service.type", NodePortService)
+			} else if p.Published != 0 && p.Mode == "ingress" {
+				target.Labels.Add("kev.service.type", LoadBalancerService)
+			} else if p.Published != 0 || (p.Published == 0 && p.Target != 0) {
+				target.Labels.Add("kev.service.type", ClusterIPService)
+			} else if p.Published == 0 {
+				target.Labels.Add("kev.service.type", HeadlessService)
+			}
+			// @todo: Processing just the first port for now!
+			break
+		}
+	}
+}
+
+// extractDeploymentLabels extracts deployment related into a label's Service.
+func extractDeploymentLabels(source composego.ServiceConfig, target *composego.ServiceConfig) {
+	extractWorkloadType(source, target)
+	extractWorkloadReplicas(source, target)
+	extractWorkloadRestartPolicy(source, target)
+	extractWorkloadResourceRequests(source, target)
+	extractWorkloadResourceLimits(source, target)
+	extractWorkloadRollingUpdatePolicy(source, target)
+}
+
+// extractWorkloadRollingUpdatePolicy extracts deployment's rolling update policy.
+func extractWorkloadRollingUpdatePolicy(source composego.ServiceConfig, target *composego.ServiceConfig) {
+	if source.Deploy != nil && source.Deploy.UpdateConfig != nil {
+		value := strconv.FormatUint(*source.Deploy.UpdateConfig.Parallelism, 10)
+		target.Labels.Add("kev.workload.rolling-update-max-surge", value)
+	}
+}
+
+// extractWorkloadResourceLimits extracts deployment's resource limits.
+func extractWorkloadResourceLimits(source composego.ServiceConfig, target *composego.ServiceConfig) {
+	if source.Deploy != nil && source.Deploy.Resources.Limits != nil {
+		target.Labels.Add("kev.workload.max-cpu", source.Deploy.Resources.Limits.NanoCPUs)
+
+		value := getMemoryQuantity(int64(source.Deploy.Resources.Limits.MemoryBytes))
+		target.Labels.Add("kev.workload.max-memory", value)
+	}
+}
+
+// extractWorkloadResourceRequests extracts deployment's resource requests.
+func extractWorkloadResourceRequests(source composego.ServiceConfig, target *composego.ServiceConfig) {
+	if source.Deploy != nil && source.Deploy.Resources.Reservations != nil {
+		target.Labels.Add("kev.workload.cpu", source.Deploy.Resources.Reservations.NanoCPUs)
+
+		value := getMemoryQuantity(int64(source.Deploy.Resources.Reservations.MemoryBytes))
+		target.Labels.Add("kev.workload.memory", value)
+	}
+}
+
+// extractWorkloadRestartPolicy extracts deployment's restart policy.
+func extractWorkloadRestartPolicy(source composego.ServiceConfig, target *composego.ServiceConfig) {
+	if source.Deploy != nil && source.Deploy.RestartPolicy != nil {
+		if source.Deploy.RestartPolicy.Condition == "on-failure" {
+			target.Labels.Add("kev.workload.restart", RestartPolicyOnFailure)
+		} else if source.Deploy.RestartPolicy.Condition == "none" {
+			target.Labels.Add("kev.workload.restart", RestartPolicyNever)
+		} else {
+			// Always restart by default
+			target.Labels.Add("kev.workload.restart", RestartPolicyAlways)
+		}
+	}
+}
+
+// extractWorkloadReplicas extracts deployment's restart policy.
+func extractWorkloadReplicas(source composego.ServiceConfig, target *composego.ServiceConfig) {
+	if source.Deploy != nil {
+		value := strconv.FormatUint(*source.Deploy.Replicas, 10)
+		target.Labels.Add("kev.workload.replicas", value)
+	}
+}
+
+// extractWorkloadType extracts deployment's workload type.
+func extractWorkloadType(source composego.ServiceConfig, target *composego.ServiceConfig) {
+	if source.Deploy != nil && source.Deploy.Mode == "global" {
+		target.Labels.Add("kev.workload.type", DaemonsetWorkload)
+	} else {
+		// replicated
+		if source.Volumes != nil {
+			// Volumes in use so likely a Statefulset
+			target.Labels.Add("kev.workload.type", StatefulsetWorkload)
+		} else {
+			// default to deployment
+			target.Labels.Add("kev.workload.type", DeploymentWorkload)
+		}
+	}
+}
+
+// extractHealthcheckLabels extracts health check labels into a label's Service.
+func extractHealthcheckLabels(source composego.ServiceConfig, target *composego.ServiceConfig) {
+	target.Labels.Add("kev.workload.liveness-probe-disable", strconv.FormatBool(source.HealthCheck.Disable))
+	target.Labels.Add("kev.workload.liveness-probe-interval", source.HealthCheck.Interval.String())
+
+	retries := strconv.FormatUint(*source.HealthCheck.Retries, 10)
+	target.Labels.Add("kev.workload.liveness-probe-retries", retries)
+
+	target.Labels.Add("kev.workload.liveness-probe-initial-delay", source.HealthCheck.StartPeriod.String())
+	target.Labels.Add("kev.workload.liveness-probe-command", formatSlice(source.HealthCheck.Test))
+	target.Labels.Add("kev.workload.liveness-probe-timeout", source.HealthCheck.Timeout.String())
+}
+
+// formatSlice formats a string slice as '["value1", "value2", "value3"]'
+func formatSlice(test []string) string {
+	quoted := fmt.Sprintf("[%q]", strings.Join(test, `", "`))
+	return strings.ReplaceAll(quoted, "\\", "")
+}
+
+// GetMemoryQuantity returns memory amount as string in Kubernetes notation
+// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
+// Example: 100Mi, 20Gi
+func getMemoryQuantity(b int64) string {
+	const unit int64 = 1024
+
+	q := resource.NewQuantity(b, resource.BinarySI)
+
+	quantity, _ := q.AsInt64()
+	if quantity%unit == 0 {
+		return q.String()
+	}
+
+	// Kubernetes resource quantity computation doesn't do well with values containing decimal points
+	// Example: 10.6Mi would translate to 11114905 (bytes)
+	// Let's keep consistent with kubernetes resource amount notation (below).
+
+	if b < unit {
+		return fmt.Sprintf("%d", b)
+	}
+
+	div, exp := unit, 0
+	for n := b / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+
+	return fmt.Sprintf("%.1f%ci", float64(b)/float64(div), "KMGTPE"[exp])
+}

--- a/pkg/kev.v2/testdata/in-cluster-wordpress/docker-compose.kev.dev.yaml
+++ b/pkg/kev.v2/testdata/in-cluster-wordpress/docker-compose.kev.dev.yaml
@@ -1,43 +1,43 @@
-version: '3.7'
+version: "3.7"
 services:
   db:
     labels:
-      io.appvia.kev.workload.image-pull-policy: "IfNotPresent"
-      io.appvia.kev.workload.service-account-name: "default"
-      io.appvia.kev.workload.type: "StatefulSet"
-      io.appvia.kev.workload.replicas: "1"
-      io.appvia.kev.workload.rolling-update-max-surge: "1"
-      io.appvia.kev.workload.cpu: "0.1"
-      io.appvia.kev.workload.memory: "10Mi"
-      io.appvia.kev.workload.max-cpu: "0.5"
-      io.appvia.kev.workload.max-memory: "500Mi"
-      io.appvia.kev.workload.liveness-probe-disable: "false"
-      io.appvia.kev.workload.liveness-probe-interval: "1m0s"
-      io.appvia.kev.workload.liveness-probe-retries: "3"
-      io.appvia.kev.workload.liveness-probe-initial-delay: "1m0s"
-      io.appvia.kev.workload.liveness-probe-command: '["CMD", "echo", "Define healthcheck command for service db"]'
-      io.appvia.kev.workload.liveness-probe-timeout: "10s"
-      io.appvia.kev.service.type: "None"
+      kev.service.type: None
+      kev.workload.cpu: "0.1"
+      kev.workload.image-pull-policy: IfNotPresent
+      kev.workload.liveness-probe-command: '["CMD", "echo", "Define healthcheck command for service db"]'
+      kev.workload.liveness-probe-disable: "false"
+      kev.workload.liveness-probe-initial-delay: 1m0s
+      kev.workload.liveness-probe-interval: 1m0s
+      kev.workload.liveness-probe-retries: "3"
+      kev.workload.liveness-probe-timeout: 10s
+      kev.workload.max-cpu: "0.5"
+      kev.workload.max-memory: 500Mi
+      kev.workload.memory: 10Mi
+      kev.workload.replicas: "1"
+      kev.workload.rolling-update-max-surge: "1"
+      kev.workload.service-account-name: default
+      kev.workload.type: StatefulSet
   wordpress:
     labels:
-      io.appvia.kev.workload.image-pull-policy: "IfNotPresent"
-      io.appvia.kev.workload.service-account-name: "default"
-      io.appvia.kev.workload.type: "Deployment"
-      io.appvia.kev.workload.replicas: "1"
-      io.appvia.kev.workload.rolling-update-max-surge: "1"
-      io.appvia.kev.workload.cpu: "0.1"
-      io.appvia.kev.workload.memory: "10Mi"
-      io.appvia.kev.workload.max-cpu: "0.5"
-      io.appvia.kev.workload.max-memory: "500Mi"
-      io.appvia.kev.workload.liveness-probe-disable: "false"
-      io.appvia.kev.workload.liveness-probe-interval: "1m0s"
-      io.appvia.kev.workload.liveness-probe-retries: "3"
-      io.appvia.kev.workload.liveness-probe-initial-delay: "1m0s"
-      io.appvia.kev.workload.liveness-probe-command: '["CMD", "echo", "Define healthcheck command for service wordpress"]'
-      io.appvia.kev.workload.liveness-probe-timeout: "10s"
-      io.appvia.kev.service.type: "LoadBalancer"
+      kev.service.type: LoadBalancer
+      kev.workload.cpu: "0.1"
+      kev.workload.image-pull-policy: IfNotPresent
+      kev.workload.liveness-probe-command: '["CMD", "echo", "Define healthcheck command for service wordpress"]'
+      kev.workload.liveness-probe-disable: "false"
+      kev.workload.liveness-probe-initial-delay: 1m0s
+      kev.workload.liveness-probe-interval: 1m0s
+      kev.workload.liveness-probe-retries: "3"
+      kev.workload.liveness-probe-timeout: 10s
+      kev.workload.max-cpu: "0.5"
+      kev.workload.max-memory: 500Mi
+      kev.workload.memory: 10Mi
+      kev.workload.replicas: "1"
+      kev.workload.rolling-update-max-surge: "1"
+      kev.workload.service-account-name: default
+      kev.workload.type: Deployment
 volumes:
   db_data:
     labels:
-      io.appvia.kev.volumes.class: "standard"
-      io.appvia.kev.volumes.size: "100Mi"
+      kev.volumes.class: standard
+      kev.volumes.size: 100Mi

--- a/pkg/kev.v2/transform.go
+++ b/pkg/kev.v2/transform.go
@@ -1,0 +1,124 @@
+/**
+ * Copyright 2020 Appvia Ltd <info@appvia.io>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package kev
+
+import (
+	"fmt"
+	"time"
+
+	composego "github.com/compose-spec/compose-go/types"
+	"github.com/imdario/mergo"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+type transform func(*composeProject) error
+
+// augmentOrAddDeploy augments a service's existing deploy block or attaches a new one with default presets.
+func augmentOrAddDeploy(x *composeProject) error {
+	var updated composego.Services
+	err := x.WithServices(x.ServiceNames(), func(svc composego.ServiceConfig) error {
+		var deploy = createDeploy()
+
+		if svc.Deploy != nil {
+			if err := mergo.Merge(&deploy, svc.Deploy, mergo.WithOverride); err != nil {
+				return err
+			}
+		}
+
+		svc.Deploy = &deploy
+		updated = append(updated, svc)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	x.Services = updated
+
+	return nil
+}
+
+// healthCheckBase attaches a base healthcheck  block with placeholders to be updated by users
+// to any service missing a healthcheck block.
+func healthCheckBase(x *composeProject) error {
+	var updated composego.Services
+	err := x.WithServices(x.ServiceNames(), func(svc composego.ServiceConfig) error {
+		if svc.HealthCheck == nil {
+			check := createHealthCheck(svc.Name)
+			svc.HealthCheck = &check
+		}
+		updated = append(updated, svc)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	x.Services = updated
+	return nil
+}
+
+// createDeploy returns a deploy block with configured presets.
+func createDeploy() composego.DeployConfig {
+	replica := uint64(DefaultReplicaNumber)
+	parallelism := uint64(defaultRollingUpdateMaxSurge)
+
+	lm, _ := resource.ParseQuantity(defaultResourceLimitMem)
+	rm, _ := resource.ParseQuantity(defaultResourceRequestMem)
+
+	defaultMemLimit, _ := lm.AsInt64()
+	defaultMemReq, _ := rm.AsInt64()
+
+	return composego.DeployConfig{
+		Replicas: &replica,
+		Mode:     "replicated",
+		Resources: composego.Resources{
+			Limits: &composego.Resource{
+				NanoCPUs:    defaultResourceLimitCPU,
+				MemoryBytes: composego.UnitBytes(defaultMemLimit),
+			},
+			Reservations: &composego.Resource{
+				NanoCPUs:    defaultResourceRequestCPU,
+				MemoryBytes: composego.UnitBytes(defaultMemReq),
+			},
+		},
+		UpdateConfig: &composego.UpdateConfig{
+			Parallelism: &parallelism,
+		},
+	}
+}
+
+// createHealthCheck returns a healthcheck block with configured placeholders.
+func createHealthCheck(svcName string) composego.HealthCheckConfig {
+	testMsg := fmt.Sprintf(defaultLivenessProbeCommand, svcName)
+	to, _ := time.ParseDuration(defaultLivenessProbeTimeout)
+	iv, _ := time.ParseDuration(defaultLivenessProbeInterval)
+	sp, _ := time.ParseDuration(defaultLivenessProbeInitialDelay)
+	timeout := composego.Duration(to)
+	interval := composego.Duration(iv)
+	startPeriod := composego.Duration(sp)
+	retries := uint64(defaultLivenessProbeRetries)
+
+	return composego.HealthCheckConfig{
+		Test:        []string{"CMD", "echo", testMsg},
+		Timeout:     &timeout,
+		Interval:    &interval,
+		Retries:     &retries,
+		StartPeriod: &startPeriod,
+		Disable:     defaultLivenessProbeDisable,
+	}
+}

--- a/pkg/kev.v2/types.go
+++ b/pkg/kev.v2/types.go
@@ -20,11 +20,27 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"path"
+	"path/filepath"
+
+	composego "github.com/compose-spec/compose-go/types"
 )
+
+type composeProject struct {
+	version string
+	*composego.Project
+}
+
+type labels struct {
+	Version  string `yaml:"version,omitempty" json:"version,omitempty"`
+	Services composego.Services
+	Volumes  composego.Volumes
+}
 
 type Manifest struct {
 	Sources      []string     `yaml:"compose,omitempty" json:"compose,omitempty"`
 	Environments Environments `yaml:"environments,omitempty" json:"environments,omitempty"`
+	labels       labels
 }
 
 // WriteTo writes out a manifest to a writer.
@@ -49,6 +65,61 @@ func (m *Manifest) GetEnvironment(name string) (Environment, error) {
 	return Environment{}, fmt.Errorf("no such environment: %s", name)
 }
 
+// ExtractLabels extracts the base set of labels from the manifest's docker-compose source files.
+func (m *Manifest) ExtractLabels() (*Manifest, error) {
+	ready, err := newComposeProject(m.Sources)
+	if err != nil {
+		return nil, err
+	}
+	m.labels = extractLabels(ready)
+	return m, nil
+}
+
+// extractLabels same as ExtractLabels but works on a compose project object.
+func extractLabels(c *composeProject) labels {
+	out := labels{
+		Version: c.version,
+	}
+	extractVolumesLabels(c, &out)
+
+	for _, s := range c.Services {
+		target := composego.ServiceConfig{
+			Name:   s.Name,
+			Labels: map[string]string{},
+		}
+		setDefaultLabels(&target)
+		extractServiceTypeLabels(s, &target)
+		extractDeploymentLabels(s, &target)
+		extractHealthcheckLabels(s, &target)
+		out.Services = append(out.Services, target)
+	}
+	return out
+}
+
+// MintEnvironments create new environments based on candidate environments and manifest base labels.
+// If no environments are provided, a default environment will be created.
+func (m *Manifest) MintEnvironments(candidates []string) *Manifest {
+	m.Environments = Environments{}
+	if len(candidates) == 0 {
+		candidates = append(candidates, defaultEnv)
+	}
+	for _, env := range candidates {
+		m.Environments = append(m.Environments, Environment{
+			Name:    env,
+			content: m.labels,
+			File:    path.Join(m.GetWorkingDir(), fmt.Sprintf(configFileTemplate, env)),
+		})
+	}
+	return m
+}
+
+func (m *Manifest) GetWorkingDir() string {
+	if len(m.Sources) < 1 {
+		return ""
+	}
+	return filepath.Dir(m.Sources[0])
+}
+
 type Environments []Environment
 
 // MarshalYAML makes Environments implement yaml.Marshaler.
@@ -71,13 +142,17 @@ func (e Environments) MarshalJSON() ([]byte, error) {
 
 type Environment struct {
 	Name    string `yaml:"-" json:"-"`
-	Content []byte `yaml:"-" json:"-"` // TODO: this will become a compose.VersionedProject
 	File    string `yaml:"-" json:"-"`
+	content labels
 }
 
 // WriteTo writes out an environment to a writer.
 // The Environment struct implements the io.WriterTo interface.
 func (e Environment) WriteTo(w io.Writer) (n int64, err error) {
-	written, err := w.Write(e.Content)
+	data, err := MarshalIndent(e.content, 2)
+	if err != nil {
+		return int64(0), err
+	}
+	written, err := w.Write(data)
 	return int64(written), err
 }


### PR DESCRIPTION
This completes #169 

- [x] Creates label `docker-compose.kev.<env>.yaml` files per `kev` environment.
- [x] Reuses previous `infer` ruleset. 
- [x] Keeps a flat package structure - as there is now less code to maintain. 