### PR TITLE
Corrected go orb version.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 orbs:
-  go: circleci/go@1.14
+  go: circleci/go@1.3.0
 
 jobs:
   build:


### PR DESCRIPTION
Completes #175 .

Note: The go orb version is not related to actual go version.