### PR TITLE
Init: Re-invoking init should be idempotent.

### DIFF
--- a/cmd/kev/cmd/root.go
+++ b/cmd/kev/cmd/root.go
@@ -38,8 +38,6 @@ func NewRootCmd() *cobra.Command {
 }
 
 func init() {
-	fmt.Println()
-
 	// This is required to help with error handling from RunE , https://github.com/spf13/cobra/issues/914#issuecomment-548411337
 	rootCmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
 		cmd.Println(err)


### PR DESCRIPTION
Resolves #198 

- Adds better init display messaging for success and error.
- Stop re-invoking init when `kev.yaml` exists.