### PR TITLE
Reconcile: environment variables with no value cause diff to fail with `types do not match`

### DIFF
--- a/pkg/kev/compose.go
+++ b/pkg/kev/compose.go
@@ -200,3 +200,12 @@ func findFirstFileFromFilesInDir(files []string, dir string) string {
 
 	return ""
 }
+
+func zeroValueUnassignedEnvVars(svc composego.ServiceConfig) {
+	emptyVal := ""
+	for key, val := range svc.Environment {
+		if val == nil {
+			svc.Environment[key] = &emptyVal
+		}
+	}
+}

--- a/pkg/kev/envs.go
+++ b/pkg/kev/envs.go
@@ -139,6 +139,7 @@ func (e *Environment) loadOverlay() (*Environment, error) {
 		if err != nil {
 			return nil, err
 		}
+		zeroValueUnassignedEnvVars(s)
 		services = append(services, ServiceConfig{Name: s.Name, Labels: s.Labels, Environment: s.Environment})
 	}
 	e.overlay = &composeOverlay{

--- a/pkg/kev/kev_reconcile_test.go
+++ b/pkg/kev/kev_reconcile_test.go
@@ -26,7 +26,9 @@ var _ = Describe("Reconcile", func() {
 			overlay, _ = kev.NewComposeProject(overlayFiles)
 		}
 		manifest, mErr = kev.Reconcile(workingDir, &reporter)
-		env, _ = manifest.GetEnvironment("dev")
+		if mErr == nil {
+			env, _ = manifest.GetEnvironment("dev")
+		}
 	})
 
 	Describe("Reconciling changes from sources", func() {
@@ -327,6 +329,18 @@ var _ = Describe("Reconcile", func() {
 			It("should create a change summary", func() {
 				Expect(reporter.String()).To(ContainSubstring(env.Name))
 				Expect(reporter.String()).To(ContainSubstring("nothing to update"))
+			})
+
+			It("should not error", func() {
+				Expect(mErr).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when compose or overlay env var is not assigned a value", func() {
+			BeforeEach(func() {
+				workingDir = "testdata/reconcile-env-var-unassigned"
+				overlayFiles = []string{workingDir + "/docker-compose.kev.dev.yaml"}
+				reporter = bytes.Buffer{}
 			})
 
 			It("should not error", func() {

--- a/pkg/kev/sources.go
+++ b/pkg/kev/sources.go
@@ -49,6 +49,8 @@ func withEnvVars(s *Sources, origin *ComposeProject) error {
 			return err
 		}
 
+		zeroValueUnassignedEnvVars(originSvc)
+
 		services = append(services, ServiceConfig{
 			Name:        svc.Name,
 			Labels:      svc.Labels,

--- a/pkg/kev/testdata/reconcile-env-var-unassigned/docker-compose.kev.dev.yaml
+++ b/pkg/kev/testdata/reconcile-env-var-unassigned/docker-compose.kev.dev.yaml
@@ -1,0 +1,27 @@
+version: "3.9"
+services:
+  db:
+    labels:
+      kev.service.type: None
+      kev.workload.cpu: "0.1"
+      kev.workload.image-pull-policy: IfNotPresent
+      kev.workload.liveness-probe-command: '["CMD", "echo", "Define healthcheck command for service db"]'
+      kev.workload.liveness-probe-disabled: "false"
+      kev.workload.liveness-probe-initial-delay: 1m0s
+      kev.workload.liveness-probe-interval: 1m0s
+      kev.workload.liveness-probe-retries: "3"
+      kev.workload.liveness-probe-timeout: 10s
+      kev.workload.max-cpu: "0.5"
+      kev.workload.max-memory: 500Mi
+      kev.workload.memory: 10Mi
+      kev.workload.replicas: "1"
+      kev.workload.rolling-update-max-surge: "1"
+      kev.workload.service-account-name: default
+      kev.workload.type: StatefulSet
+    environment:
+      - TO_OVERRIDE
+volumes:
+  db_data:
+    labels:
+      kev.volume.size: 100Mi
+      kev.volume.storage-class: standard

--- a/pkg/kev/testdata/reconcile-env-var-unassigned/docker-compose.yaml
+++ b/pkg/kev/testdata/reconcile-env-var-unassigned/docker-compose.yaml
@@ -1,0 +1,17 @@
+version: '3.9'
+services:
+  db:
+    image: mysql:8.0.19
+    command: '--default-authentication-plugin=mysql_native_password'
+    restart: always
+    volumes:
+      - db_data:/var/lib/mysql
+    environment:
+      - MYSQL_ROOT_PASSWORD=somewordpress
+      - MYSQL_DATABASE=wordpress
+      - MYSQL_USER=wordpress
+      - MYSQL_PASSWORD
+      - TO_OVERRIDE=value
+volumes:
+  db_data:
+

--- a/pkg/kev/testdata/reconcile-env-var-unassigned/kev.yaml
+++ b/pkg/kev/testdata/reconcile-env-var-unassigned/kev.yaml
@@ -1,0 +1,4 @@
+compose:
+  - testdata/reconcile-env-var-unassigned/docker-compose.yaml
+environments:
+  dev: testdata/reconcile-env-var-unassigned/docker-compose.kev.dev.yaml


### PR DESCRIPTION
Resolves #214 

- Assigns a blank string (zero value) to empty env vars (previously assigned nils).
- Fixes diffs.
- Adds specs to simulate the bug.
